### PR TITLE
Specify MDV commit in README instead of using submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "MDV"]
-	path = MDV
-	url = https://github.com/Taylor-CCB-Group/MDV

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The MDV viewer html and static assets are hosted in this repo
 under `templates/mdv/index.html` and `omero_mdv/static/mdv/`
 
 We need to build the MDV viewer to use relative links to static assets.
-This is currently configured on this branch: https://github.com/will-moore/MDV/tree/vite_config_base
+This is currently configured on this branch: https://github.com/will-moore/MDV/tree/omero-mdv-build
 
 Checkout that branch (rebase if desired), then build and copy assets to this repo:
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,19 @@ Then go to http://localhost:4080/
 # Update MDV viewer
 
 The MDV viewer html and static assets are hosted in this repo
-under `templates/mdv/index.html` and `omero_mdv/static/mdv/`.
-These assets are built from the MDV project that is included as a submodule.
+under `templates/mdv/index.html` and `omero_mdv/static/mdv/`
+
+We need to build the MDV viewer to use relative links to static assets.
+This is currently configured on this branch: https://github.com/will-moore/MDV/tree/vite_config_base
+
+Checkout that branch (rebase if desired), then build and copy assets to this repo:
 
 ```
-    # checkout the MDV project
-    $ git submodule init
-    $ git submodule update
-    $ cd MDV
-
-    # install the JavaScript dependencies and build
     $ npm install
     $ npm run vite-build
 
-    # copy the assests into the correct locations
-    $ cp -r vite-dist/assets/ ../omero_mdv/static/mdv/assets/
-    $ cp vite-dist/index.html ../omero_mdv/templates/mdv/
+    $ cp -r vite-dist/assets/ /path/to/omero-mdv/omero_mdv/static/mdv/assets/
+    $ cp vite-dist/index.html /path/to/omero-mdv/omero_mdv/templates/mdv/
 ```
 
 NB: if you need to use a different branch or commit of MDV, you should


### PR DESCRIPTION
Using submodules to specify the version of MDV that we depend on causes issues with deployment on the merge-ci server:

```
01:05:35 + pip install git+https://github.com/will-moore/omero-mdv.git@main#egg=omero-mdv
01:05:36 Collecting omero-mdv
01:05:36   Cloning https://github.com/will-moore/omero-mdv.git (to revision main) to /tmp/pip-install-dnbhw62p/omero-mdv_6145150331514880a0502360a04f7dd7
01:05:36   Running command git clone --quiet https://github.com/will-moore/omero-mdv.git /tmp/pip-install-dnbhw62p/omero-mdv_6145150331514880a0502360a04f7dd7
01:05:37   Resolved https://github.com/will-moore/omero-mdv.git to commit df242cf14747d7ddf9ca46bce8fbe682efe18bb3
01:05:37   Running command git submodule update --init --recursive -q
01:05:37   perl: warning: Setting locale failed.
01:05:37   perl: warning: Please check that your locale settings:
01:05:37         LANGUAGE = (unset),
01:05:37         LC_ALL = (unset),
01:05:37         LANG = "en_US.UTF-8"
01:05:37       are supported and installed on your system.
01:05:37   perl: warning: Falling back to the standard locale ("C").
01:05:37   perl: warning: Setting locale failed.
01:05:37   perl: warning: Please check that your locale settings:
01:05:37         LANGUAGE = (unset),
01:05:37         LC_ALL = (unset),
01:05:37         LANG = "en_US.UTF-8"
01:05:37       are supported and installed on your system.
01:05:37   perl: warning: Falling back to the standard locale ("C").
01:05:43   fatal: reference is not a tree: ff30874293a311de5fd697417672c01dcfc00595
01:05:43   Unable to checkout 'ff30874293a311de5fd697417672c01dcfc00595' in submodule path 'MDV'
01:05:43   error: subprocess-exited-with-error
01:05:43   
01:05:43   �� git submodule update --init --recursive -q did not run successfully.
01:05:43   ��� exit code: 1
01:05:43   ������> See above for output.
01:05:43   
01:05:43   note: This error originates from a subprocess, and is likely not a problem with pip.
01:05:43 error: subprocess-exited-with-error
01:05:43 
01:05:43 �� git submodule update --init --recursive -q did not run successfully.
01:05:43 ��� exit code: 1
01:05:43 ������> See above for output.
01:05:43 
01:05:43 note: This error originates from a subprocess, and is likely not a problem with pip.
01:05:43 Build step 'Execute shell' marked build as failure
01:05:44 Finished: FAILURE
```

Tried fixing the locale issues but that needs to happen in the Dockerfile itself https://github.com/ome/devspace/blob/master/web/Dockerfile but that is currently being updated to Rocky9.

Temporarily revert the usage of submodule - since we don't need it for building etc. 